### PR TITLE
straight path between two locations on a grid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,8 @@ lazy val geohex = crossProject.in(file(".")).
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.4" % "test",
       "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",
-      "io.spray" %% "spray-json" % "1.3.2" % "test"),
+      "io.spray" %% "spray-json" % "1.3.2" % "test",
+      "com.vividsolutions" % "jts" % "1.13" % "test"),
     bintrayOrganization := Some("teralytics")
   ).
   jsSettings(

--- a/jvm/src/test/scala/net/teralytics/terahex/Generators.scala
+++ b/jvm/src/test/scala/net/teralytics/terahex/Generators.scala
@@ -31,6 +31,13 @@ object Generators {
     lat <- latsDefinedForMercator
   } yield LatLon(Lon(lon), Lat(lat))
 
+  val shortGeoLines = for {
+    a <- latlons.suchThat { case LatLon(Lon(x), Lat(y)) => abs(x) < 170 && abs(y) < 70 }
+    dx <- chooseNum(-0.1, 0.1)
+    dy <- chooseNum(-0.1, 0.1)
+    b = LatLon(Lon(a.lon.lon + dx), Lat(a.lat.lat + dy))
+  } yield (a, b)
+
   val allLevels = 0 to 15
 
   def levels = oneOf(allLevels) :| "level"

--- a/jvm/src/test/scala/net/teralytics/terahex/GeoConversions.scala
+++ b/jvm/src/test/scala/net/teralytics/terahex/GeoConversions.scala
@@ -1,0 +1,29 @@
+package net.teralytics.terahex
+
+import com.vividsolutions.jts.geom.{ Point => GeoPoint, MultiPolygon, Polygon, GeometryFactory, Coordinate }
+
+object GeoConversions {
+
+  implicit class LatLonGeoOps(val loc: LatLon) extends AnyVal {
+
+    def toCoordinate: Coordinate = new Coordinate(loc.lon.lon, loc.lat.lat)
+
+    def toGeometry(implicit gf: GeometryFactory): GeoPoint = gf.createPoint(toCoordinate)
+  }
+
+  implicit class ZoneGeoOps(val zone: Zone) extends AnyVal {
+
+    def toGeometry(implicit gf: GeometryFactory): Polygon = {
+      val coords = zone.geometry.map(_.toCoordinate)
+      val closedRing = coords :+ coords.head
+      gf.createPolygon(closedRing.toArray)
+    }
+  }
+
+  implicit class PolygonSeqOps[A <: Polygon](val seq: Seq[A]) extends AnyVal {
+
+    def combine(implicit gf: GeometryFactory): MultiPolygon =
+      gf.createMultiPolygon(seq.toArray)
+  }
+
+}

--- a/jvm/src/test/scala/net/teralytics/terahex/GeometryMatchers.scala
+++ b/jvm/src/test/scala/net/teralytics/terahex/GeometryMatchers.scala
@@ -1,0 +1,38 @@
+package net.teralytics.terahex
+
+import com.vividsolutions.jts.geom.Geometry
+import org.scalatest.enablers.Containing
+import org.scalatest.matchers.{ MatchResult, Matcher }
+
+trait GeometryMatchers {
+
+  def matcherPrecision: Double = 1e-5
+
+  def intersect(other: Geometry) = new Matcher[Geometry] {
+    override def apply(left: Geometry) = MatchResult(
+      left.intersects(other),
+      s"\n$left\ndid not intersect\n$other",
+      s"\n$left\nintersects\n$other")
+  }
+
+  def cover(other: Geometry) = new Matcher[Geometry] {
+    override def apply(left: Geometry) = MatchResult(
+      left.buffer(matcherPrecision).covers(other),
+      s"\n$left\ndid not cover\n$other",
+      s"\n$left\ncovers\n$other")
+  }
+
+  implicit def containingNatureOfGeometry = new Containing[Geometry] {
+
+    override def contains(container: Geometry, element: Any): Boolean = element match {
+      case g: Geometry => container.buffer(matcherPrecision).contains(g)
+      case _ => false
+    }
+
+    override def containsOneOf(container: Geometry, elements: Seq[Any]): Boolean =
+      elements.exists(contains(container, _))
+
+    override def containsNoneOf(container: Geometry, elements: Seq[Any]): Boolean =
+      elements.forall(!contains(container, _))
+  }
+}

--- a/jvm/src/test/scala/net/teralytics/terahex/PathSpec.scala
+++ b/jvm/src/test/scala/net/teralytics/terahex/PathSpec.scala
@@ -1,0 +1,62 @@
+package net.teralytics.terahex
+
+import com.vividsolutions.jts.geom.{ GeometryFactory, PrecisionModel }
+import net.teralytics.terahex.GeoConversions._
+import net.teralytics.terahex.Generators._
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{ FlatSpec, Matchers }
+
+class PathSpec extends FlatSpec with PropertyChecks with Matchers with GeometryMatchers {
+
+  implicit val geoFactory = {
+    val scale = 1e9
+    val wgs84 = 4326
+    new GeometryFactory(new PrecisionModel(scale), wgs84)
+  }
+
+  "Hexagon path between two location" should "cover start and end" in forAll(geoGrids) { implicit g =>
+    forAll(shortGeoLines) { case (start, end) =>
+      val hexagons = Zone.zonesBetween(start -> end, level = 9)
+        .map(_.toGeometry)
+        .combine
+      hexagons should cover(start.toGeometry)
+      hexagons should cover(end.toGeometry)
+    }
+  }
+
+  it should "produce distinct tiles" in forAll(geoGrids) { implicit g =>
+    forAll(shortGeoLines) { line =>
+
+      val zones = Zone.zonesBetween(line, level = 9)
+      zones should be(zones.distinct)
+    }
+  }
+
+  it should "produce contiguous sequence of tiles" in forAll(geoGrids) { implicit g =>
+    forAll(shortGeoLines) { line =>
+
+      val hexagons = Zone.zonesBetween(line, level = 9).map(_.toGeometry)
+      hexagons.sliding(2).foreach {
+        case Seq(single) =>
+        case Seq(left, right) =>
+          left.distance(right) should be(0d +- matcherPrecision)
+      }
+    }
+  }
+
+  it should "intersect with padded line" in forAll(geoGrids) { implicit g =>
+    forAll(shortGeoLines) { case (start, end) =>
+
+      val level = 9
+      val hexagons = Zone.zonesBetween(start -> end, level).map(_.toGeometry)
+      val paddedLine = geoFactory
+        .createLineString(Array(start.toCoordinate, end.toCoordinate))
+        .buffer(g.size(level))
+
+      hexagons.foreach { hex =>
+        paddedLine should intersect(hex)
+      }
+    }
+  }
+
+}

--- a/shared/src/main/scala/net/teralytics/terahex/Zone.scala
+++ b/shared/src/main/scala/net/teralytics/terahex/Zone.scala
@@ -90,4 +90,17 @@ object Zone {
       we <- towardsEast(sn)
     } yield we
   }
+
+  def zonesBetween(line: (LatLon, LatLon), level: Int)(implicit grid: Grid): Seq[Zone] = {
+    val (from, to) = line
+    val size = grid.size(level)
+    val a = from.toPoint.toHex.toCell(size)
+    val b = to.toPoint.toHex.toCell(size)
+
+    a.pathTo(b)
+      .map(_.toHex(size))
+      .map(_.toPoint)
+      .map(LatLon(_))
+      .map(Zone(_, level))
+  }
 }


### PR DESCRIPTION
Implement a variation of the [Bresenham's line drawing algorithm](https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm) for hexagonal grids as described on [Red Blob Games](http://www.redblobgames.com/grids/hexagons/#line-drawing).

The algorithms computes a contiguous path of hexagons from the starting point of the line to the end point of the line. This path might not fully cover the line as can be seen on the picture:
![b19d458c-9da5-11e5-94ee-1f9c5e13395f](https://cloud.githubusercontent.com/assets/124065/11712211/6f9d0e70-9f66-11e5-8280-d79941305cb2.png)
### Usage

```
implicit val grid: Grid = ???
val start: LatLon = ???
val end: LatLon = ???
val zones = Zone.zonesBetween(start -> end, level = 9)
```
