### PR TITLE
make root size customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Use the functions of the `terahex` object:
 
     function size(level) // Returns hexagon side length in degrees at a given level
 
+    function withRootSize(sizeAtLevelZero) // Returns a terahex object with a given root size
+
     function zonesWithin(fromLon, fromLat, toLon, toLat, level) // Returns an array of Zones within the bounding box
 
 The resulting `Zone` object has properties:

--- a/js/src/main/scala/net/teralytics/terahex/TeraHex.scala
+++ b/js/src/main/scala/net/teralytics/terahex/TeraHex.scala
@@ -6,9 +6,13 @@ import js.JSConverters._
 
 @JSExport("terahex")
 @JSExportAll
-object TeraHex {
+object TeraHex extends GridJs(300)
 
-  private[this] implicit val grid: Grid = Grid(300)
+@JSExportAll
+@JSName("Grid")
+class GridJs(rootSize: Double) {
+
+  private[this] implicit val grid: Grid = Grid(rootSize)
   private[this] implicit val encoding: Encoding[String] = StringEncoding
 
   def encode(lon: Double, lat: Double, level: Int): String = zoneByLocation(lon, lat, level).code
@@ -23,6 +27,8 @@ object TeraHex {
     Zone.zonesWithin(LatLon(Lon(fromLon), Lat(fromLat)) -> LatLon(Lon(toLon), Lat(toLat)), level)
       .map(new ZoneJs(_))
       .toJSArray
+
+  def withRootSize(size: Double): GridJs = new GridJs(size)
 }
 
 object StringEncoding extends Encoding[String] {


### PR DESCRIPTION
Addressing #9 with an ability to create `terahex` objects with custom root size.

``` javascript
terahex.withRootSize(400).size(5)
```
