### PR TITLE
Fixing the missing closing point in WellKnownText in Zones built in g…

### DIFF
--- a/jvm/src/test/scala/net/teralytics/geohex/ZoneSpec.scala
+++ b/jvm/src/test/scala/net/teralytics/geohex/ZoneSpec.scala
@@ -1,0 +1,17 @@
+package net.teralytics.geohex
+
+import com.vividsolutions.jts.geom.{GeometryFactory, PrecisionModel}
+import com.vividsolutions.jts.io.WKTReader
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class ZoneSpec extends FlatSpec with PropertyChecks with Matchers {
+
+  it should "create a WellKnownText in which the starting point is equal to the ending point" in {
+    val zones = GeoHex.getZonesWithin(((51d, 21d),(56d, 22d)), 2)
+    val defaultSRID = 4326
+    val factory = new GeometryFactory(new PrecisionModel(1e7), defaultSRID)
+    val zoneCoords = new WKTReader(factory).read(zones.head.toWellKnownText).getCoordinates
+    zoneCoords.head should equal(zoneCoords.last)
+  }
+}

--- a/jvm/src/test/scala/net/teralytics/terahex/ZoneSpec.scala
+++ b/jvm/src/test/scala/net/teralytics/terahex/ZoneSpec.scala
@@ -4,6 +4,9 @@ import org.scalatest.{ Matchers, FlatSpec }
 import org.scalatest.prop.PropertyChecks
 import scala.math._
 
+import com.vividsolutions.jts.geom.{GeometryFactory, PrecisionModel}
+import com.vividsolutions.jts.io.{WKTReader}
+
 class ZoneSpec extends FlatSpec with PropertyChecks with Matchers {
 
   import Generators._
@@ -45,5 +48,14 @@ class ZoneSpec extends FlatSpec with PropertyChecks with Matchers {
     val codes = Zone.zonesWithin(LatLon(Lon(-50), Lat(-50)) -> LatLon(Lon(50), Lat(50)), 5)
       .map(_.code)
     codes should contain theSameElementsInOrderAs codes.distinct
+  }
+
+  it should "create a WellKnownText in which the starting point is equal to the ending point" in {
+    implicit val grid = TeraHex.grid
+    val defaultSRID = 4326
+    val zones = Zone.zonesWithin(LatLon(Lon(51), Lat(21)) -> LatLon(Lon(56), Lat(22)), 5)
+    val factory = new GeometryFactory(new PrecisionModel(1e7), defaultSRID)
+    val zoneCoords = new WKTReader(factory).read(zones.head.toWellKnownText).getCoordinates
+    zoneCoords.head should equal(zoneCoords.last)
   }
 }

--- a/shared/src/main/scala/net/teralytics/geohex/Zone.scala
+++ b/shared/src/main/scala/net/teralytics/geohex/Zone.scala
@@ -46,9 +46,12 @@ case class Zone(code: String, lat: Double = 0, lon: Double = 0, x: Long = 0, y: 
 
   val size: Double = circumradiusInMetersAtEquator(level)
 
-  def toWellKnownText: String = getHexCoords
-    .map(loc => s"${loc.lon} ${loc.lat}")
-    .mkString("POLYGON ((", ", ", "))")
+  def toWellKnownText: String = {
+    val polygons = getHexCoords
+    (polygons :+ polygons.head)
+      .map(loc => s"${loc.lon} ${loc.lat}")
+      .mkString("POLYGON ((", ", ", "))")
+  }
 
   def getHexCoords: Array[Loc] = {
     val xy = loc2xy(lon, lat)


### PR DESCRIPTION
This should resolve the issue #22 

#### Description

The method `toWellKnownText()` in the case class Zone of the package `net.teralytics.geohex` is not closing the geometry with the first point as required by WKT of polygons.

#### Tests

Tests: succeeded 43, failed 0, canceled 0, ignored 0, pending 0